### PR TITLE
feat: read down_ratio to calculate the correct CP usage

### DIFF
--- a/src/powermetrics.rs
+++ b/src/powermetrics.rs
@@ -74,6 +74,8 @@ struct RawCluster {
     freq_hz: f64,
     idle_ratio: f64,
     #[serde(default)]
+    down_ratio: f64,
+    #[serde(default)]
     cpus: Vec<RawCore>,
 }
 
@@ -89,6 +91,8 @@ struct RawCore {
     cpu: u32,
     freq_hz: f64,
     idle_ratio: f64,
+    #[serde(default)]
+    down_ratio: f64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -224,10 +228,11 @@ fn convert_snapshot(raw: RawSnapshot) -> PowermetricsReading {
             name,
             freq_hz,
             idle_ratio,
+            down_ratio,
             cpus,
         } = cluster;
         let freq_mhz = display_freq(freq_hz);
-        let active = ratio_to_pct(idle_ratio);
+        let active = ratio_to_pct(idle_ratio + down_ratio);
         let is_e = name.starts_with(['E', 'e']);
         if is_e {
             e_clusters.push(ClusterData {
@@ -245,7 +250,7 @@ fn convert_snapshot(raw: RawSnapshot) -> PowermetricsReading {
         for core in cpus {
             let metrics = CoreMetrics {
                 id: core.cpu,
-                active_pct: ratio_to_pct(core.idle_ratio),
+                active_pct: ratio_to_pct(core.idle_ratio + core.down_ratio),
                 freq_mhz: display_freq(core.freq_hz),
             };
             if is_e {
@@ -295,7 +300,8 @@ fn ratio_to_pct(idle_ratio: f64) -> u64 {
     if !idle_ratio.is_finite() {
         return 0;
     }
-    let ratio = if idle_ratio > 1.0 {
+    // Buggy as ratio > 1.0 may be true (due to floating point representation)
+    let ratio = if idle_ratio > 1.0001 {
         idle_ratio / 100.0
     } else {
         idle_ratio


### PR DESCRIPTION
This solves issue #1, by adding reading down_ratio provided by powermetrics. 
I'm not sure if old macOS systems provides this key, but in theory a default value should be provided. 

Befor patching:
<img width="416" height="215" alt="image" src="https://github.com/user-attachments/assets/177d5769-2b01-4b52-b840-35e6bfa2d2fe" />
<img width="416" height="168" alt="image" src="https://github.com/user-attachments/assets/f27bf150-1c2e-40b5-b7fd-3e9ace940903" />

After patching:
<img width="416" height="154" alt="image" src="https://github.com/user-attachments/assets/98ad01eb-444a-4112-aa72-8ed2600731cb" />
<img width="416" height="158" alt="image" src="https://github.com/user-attachments/assets/77301c80-ae87-424f-85d6-e1178051f297" />
