### PR TITLE
Use pipe to read powermetrics output to avoid disk write

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,6 @@ pub struct Cli {
     pub show_cores: bool,
 
     /// Restart powermetrics after this many samples (0 = never restart).
-    #[arg(long, default_value_t = 0, value_name = "COUNT")]
+    #[arg(long, default_value_t = 0, value_name = "COUNT(Deprecated)")]
     pub max_count: u64,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use io_stats::{IoSampler, IoStats};
 use memory::{MemoryReader, MemoryStats};
 use powermetrics::{
     CpuMetrics, GpuMetrics, History, PowermetricsReader, PowermetricsReading, RollingAverage,
-    cleanup_powermetrics_files, new_timecode, run_powermetrics,
+    cleanup_powermetrics_files, run_powermetrics,
 };
 use ratatui::{Terminal, backend::CrosstermBackend, prelude::*};
 use soc::SocInfo;
@@ -78,9 +78,8 @@ fn main() -> Result<()> {
     cleanup_powermetrics_files().ok();
 
     println!("[2/3] Starting powermetrics process\n");
-    let timecode = new_timecode();
     let mut child =
-        run_powermetrics(&timecode, cli.interval * 1000).context("failed to spawn powermetrics")?;
+        run_powermetrics(cli.interval * 1000).context("failed to spawn powermetrics")?;
     // Extract stdout to create reader
     let child_stdout = child.stdout.take().expect("failed to get stdout");
     // Wrap child in RAII guard to ensure cleanup on panic or early return

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,18 +44,6 @@ impl PowermetricsGuard {
         Self { child: Some(child) }
     }
 
-    /// Kill and restart the process with a new timecode
-    fn restart(&mut self, timecode: &str, interval_ms: u64) -> Result<()> {
-        // Kill existing process first
-        if let Some(ref mut child) = self.child {
-            child.kill().ok();
-            child.wait().ok();
-        }
-        // Start new process
-        self.child = Some(run_powermetrics(timecode, interval_ms)?);
-        Ok(())
-    }
-
     /// Explicitly stop the child process
     fn stop(&mut self) {
         if let Some(ref mut child) = self.child {
@@ -91,11 +79,14 @@ fn main() -> Result<()> {
 
     println!("[2/3] Starting powermetrics process\n");
     let mut timecode = new_timecode();
-    let child =
+    let mut child =
         run_powermetrics(&timecode, cli.interval * 1000).context("failed to spawn powermetrics")?;
+    // Extract stdout to create reader
+    let child_stdout = child.stdout.take().expect("failed to get stdout");
     // Wrap child in RAII guard to ensure cleanup on panic or early return
     let mut guard = PowermetricsGuard::new(child);
-    let mut pm_reader = PowermetricsReader::new(&timecode);
+    // Create reader from child's stdout stream
+    let mut pm_reader = PowermetricsReader::from_stdout(child_stdout);
     println!("[3/3] Waiting for first reading...\n");
 
     let first_reading = wait_for_reading(&mut pm_reader, Duration::from_millis(100))
@@ -193,13 +184,24 @@ fn run_ui(
             }
         }
 
-        if state.config.max_count > 0 && state.samples_taken >= state.config.max_count {
-            *timecode = new_timecode();
-            guard.restart(timecode, state.config.interval * 1000)?;
-            pm_reader.set_timecode(timecode);
-            state.samples_taken = 0;
-            state.last_timestamp = None;
-        }
+        // if state.config.max_count > 0 && state.samples_taken >= state.config.max_count {
+        //     *timecode = new_timecode();
+        //     // Manually restart: kill old child and spawn new one
+        //     if let Some(ref mut child) = guard.child {
+        //         child.kill().ok();
+        //         child.wait().ok();
+        //     }
+        //     // Spawn new child
+        //     let mut new_child =
+        //         run_powermetrics(timecode, state.config.interval * 1000)
+        //             .context("failed to restart powermetrics")?;
+        //     // Extract stdout and create new reader
+        //     let child_stdout = new_child.stdout.take().expect("failed to get stdout");
+        //     guard.child = Some(new_child);
+        //     *pm_reader = PowermetricsReader::from_stdout(child_stdout);
+        //     state.samples_taken = 0;
+        //     state.last_timestamp = None;
+        // }
 
         if needs_redraw {
             terminal.draw(|f| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ fn main() -> Result<()> {
     cleanup_powermetrics_files().ok();
 
     println!("[2/3] Starting powermetrics process\n");
-    let mut timecode = new_timecode();
+    let timecode = new_timecode();
     let mut child =
         run_powermetrics(&timecode, cli.interval * 1000).context("failed to spawn powermetrics")?;
     // Extract stdout to create reader
@@ -98,8 +98,6 @@ fn main() -> Result<()> {
 
     let result = run_ui(
         &mut state,
-        &mut guard,
-        &mut timecode,
         &mut pm_reader,
         &mut memory_reader,
         &mut io_sampler,
@@ -150,8 +148,6 @@ fn cleanup_terminal() -> Result<()> {
 
 fn run_ui(
     state: &mut AppState,
-    guard: &mut PowermetricsGuard,
-    timecode: &mut String,
     pm_reader: &mut PowermetricsReader,
     memory_reader: &mut MemoryReader,
     io_sampler: &mut IoSampler,
@@ -183,25 +179,6 @@ fn run_ui(
                 }
             }
         }
-
-        // if state.config.max_count > 0 && state.samples_taken >= state.config.max_count {
-        //     *timecode = new_timecode();
-        //     // Manually restart: kill old child and spawn new one
-        //     if let Some(ref mut child) = guard.child {
-        //         child.kill().ok();
-        //         child.wait().ok();
-        //     }
-        //     // Spawn new child
-        //     let mut new_child =
-        //         run_powermetrics(timecode, state.config.interval * 1000)
-        //             .context("failed to restart powermetrics")?;
-        //     // Extract stdout and create new reader
-        //     let child_stdout = new_child.stdout.take().expect("failed to get stdout");
-        //     guard.child = Some(new_child);
-        //     *pm_reader = PowermetricsReader::from_stdout(child_stdout);
-        //     state.samples_taken = 0;
-        //     state.last_timestamp = None;
-        // }
 
         if needs_redraw {
             terminal.draw(|f| {

--- a/src/powermetrics.rs
+++ b/src/powermetrics.rs
@@ -6,7 +6,7 @@ use std::{
     fs::{self},
     io::{Cursor, Read,},
     process::{Child, Command, Stdio},
-    time::{SystemTime, UNIX_EPOCH},
+    time::{SystemTime},
 };
 
 const MAX_READ_BYTES: u64 = 1 * 1024 * 1024; // 1 MiB from EOF is enough for one sample
@@ -98,7 +98,7 @@ struct RawGpu {
 }
 
 
-pub fn run_powermetrics(_timecode: &str, interval_ms: u64) -> Result<Child> {
+pub fn run_powermetrics(interval_ms: u64) -> Result<Child> {
     cleanup_powermetrics_files().ok();
     let interval_arg = interval_ms.to_string();
     let mut cmd = Command::new("sudo");
@@ -133,14 +133,6 @@ pub fn cleanup_powermetrics_files() -> Result<()> {
         }
     }
     Ok(())
-}
-
-pub fn new_timecode() -> String {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    now.to_string()
 }
 
 /// Cached reader for powermetrics stream to reduce unnecessary I/O

--- a/src/powermetrics.rs
+++ b/src/powermetrics.rs
@@ -3,13 +3,12 @@ use plist::{self, Date};
 use serde::Deserialize;
 use std::{
     collections::VecDeque,
-    fs::{self, File},
-    io::{Cursor, Read, Seek, SeekFrom},
+    fs::{self},
+    io::{Cursor, Read,},
     process::{Child, Command, Stdio},
     time::{SystemTime, UNIX_EPOCH},
 };
 
-const POWER_FILE_PREFIX: &str = "/tmp/asitop_powermetrics";
 const MAX_READ_BYTES: u64 = 1 * 1024 * 1024; // 1 MiB from EOF is enough for one sample
 
 #[derive(Debug, Clone)]
@@ -98,9 +97,6 @@ struct RawGpu {
     idle_ratio: f64,
 }
 
-pub fn powermetrics_path(timecode: &str) -> String {
-    format!("{POWER_FILE_PREFIX}{timecode}")
-}
 
 pub fn run_powermetrics(_timecode: &str, interval_ms: u64) -> Result<Child> {
     cleanup_powermetrics_files().ok();
@@ -150,49 +146,17 @@ pub fn new_timecode() -> String {
 /// Cached reader for powermetrics stream to reduce unnecessary I/O
 pub struct PowermetricsReader {
     reader: Box<dyn Read + Send>,
-    path: Option<String>,
-    last_len: u64,
     buffer: Vec<u8>,
 }
 
 impl PowermetricsReader {
-    // /// Create a new reader from a child process's stdout
-    // pub fn from_child(mut child: Child) -> Self {
-    //     let stdout = child.stdout.take().expect("failed to get stdout from powermetrics");
-    //     Self {
-    //         reader: Some(Box::new(stdout) as Box<dyn Read + Send>),
-    //         path: None,
-    //         last_len: 0,
-    //         buffer: Vec::with_capacity(MAX_READ_BYTES as usize),
-    //     }
-    // }
-
     /// Create a new reader from a stdout stream
     pub fn from_stdout(stdout: std::process::ChildStdout) -> Self {
         Self {
             reader: Box::new(stdout) as Box<dyn Read + Send>,
-            path: None,
-            last_len: 0,
             buffer: Vec::with_capacity(MAX_READ_BYTES as usize),
         }
     }
-
-    // /// Create a new reader from a file (legacy mode)
-    // pub fn from_file(timecode: &str) -> Self {
-    //     Self {
-    //         reader: None,
-    //         path: Some(powermetrics_path(timecode)),
-    //         last_len: 0,
-    //         buffer: Vec::with_capacity(MAX_READ_BYTES as usize),
-    //     }
-    // }
-
-    // /// Switch to reading from a new file (for restart)
-    // pub fn set_timecode(&mut self, timecode: &str) {
-    //     self.path = Some(powermetrics_path(timecode));
-    //     self.last_len = 0;
-    //     self.reader = None;
-    // }
 
     pub fn parse(&mut self) -> Result<Option<PowermetricsReading>> {
         // Stream-based reading (pipe mode)

--- a/src/powermetrics.rs
+++ b/src/powermetrics.rs
@@ -102,9 +102,8 @@ pub fn powermetrics_path(timecode: &str) -> String {
     format!("{POWER_FILE_PREFIX}{timecode}")
 }
 
-pub fn run_powermetrics(timecode: &str, interval_ms: u64) -> Result<Child> {
+pub fn run_powermetrics(_timecode: &str, interval_ms: u64) -> Result<Child> {
     cleanup_powermetrics_files().ok();
-    let path = powermetrics_path(timecode);
     let interval_arg = interval_ms.to_string();
     let mut cmd = Command::new("sudo");
     cmd.args([
@@ -114,15 +113,13 @@ pub fn run_powermetrics(timecode: &str, interval_ms: u64) -> Result<Child> {
         "powermetrics",
         "--samplers",
         "cpu_power,gpu_power,thermal",
-        "-o",
-        &path,
         "-f",
         "plist",
         "-i",
         &interval_arg,
     ])
     .stdin(Stdio::null())
-    .stdout(Stdio::null())
+    .stdout(Stdio::piped())
     .stderr(Stdio::null());
 
     cmd.spawn().with_context(|| "failed to spawn powermetrics")
@@ -150,62 +147,88 @@ pub fn new_timecode() -> String {
     now.to_string()
 }
 
-/// Cached reader for powermetrics file to reduce unnecessary I/O
+/// Cached reader for powermetrics stream to reduce unnecessary I/O
 pub struct PowermetricsReader {
-    path: String,
+    reader: Box<dyn Read + Send>,
+    path: Option<String>,
     last_len: u64,
     buffer: Vec<u8>,
 }
 
 impl PowermetricsReader {
-    pub fn new(timecode: &str) -> Self {
+    // /// Create a new reader from a child process's stdout
+    // pub fn from_child(mut child: Child) -> Self {
+    //     let stdout = child.stdout.take().expect("failed to get stdout from powermetrics");
+    //     Self {
+    //         reader: Some(Box::new(stdout) as Box<dyn Read + Send>),
+    //         path: None,
+    //         last_len: 0,
+    //         buffer: Vec::with_capacity(MAX_READ_BYTES as usize),
+    //     }
+    // }
+
+    /// Create a new reader from a stdout stream
+    pub fn from_stdout(stdout: std::process::ChildStdout) -> Self {
         Self {
-            path: powermetrics_path(timecode),
+            reader: Box::new(stdout) as Box<dyn Read + Send>,
+            path: None,
             last_len: 0,
             buffer: Vec::with_capacity(MAX_READ_BYTES as usize),
         }
     }
 
-    pub fn set_timecode(&mut self, timecode: &str) {
-        self.path = powermetrics_path(timecode);
-        self.last_len = 0;
-    }
+    // /// Create a new reader from a file (legacy mode)
+    // pub fn from_file(timecode: &str) -> Self {
+    //     Self {
+    //         reader: None,
+    //         path: Some(powermetrics_path(timecode)),
+    //         last_len: 0,
+    //         buffer: Vec::with_capacity(MAX_READ_BYTES as usize),
+    //     }
+    // }
+
+    // /// Switch to reading from a new file (for restart)
+    // pub fn set_timecode(&mut self, timecode: &str) {
+    //     self.path = Some(powermetrics_path(timecode));
+    //     self.last_len = 0;
+    //     self.reader = None;
+    // }
 
     pub fn parse(&mut self) -> Result<Option<PowermetricsReading>> {
-        let mut file = match File::open(&self.path) {
-            Ok(f) => f,
+        // Stream-based reading (pipe mode)
+        let reader = self.reader.as_mut();
+
+        // Read new data into buffer
+        let mut temp_buf = [0u8; 8192];
+        let bytes_read = match reader.read(&mut temp_buf) {
+            Ok(n) => n,
             Err(_) => return Ok(None),
         };
 
-        let len = file.metadata().map(|m| m.len()).unwrap_or(0);
-        if len == 0 {
+        if bytes_read == 0 {
             return Ok(None);
         }
 
-        // Skip if file size hasn't changed
-        if len == self.last_len {
-            return Ok(None);
-        }
-        self.last_len = len;
-
-        let start = len.saturating_sub(MAX_READ_BYTES);
-        if file.seek(SeekFrom::Start(start)).is_err() {
-            file.seek(SeekFrom::Start(0)).ok();
-        }
-
-        self.buffer.clear();
-        if let Err(e) = file.read_to_end(&mut self.buffer) {
-            if self.buffer.is_empty() {
-                return Err(anyhow::anyhow!("failed to read powermetrics chunk: {}", e));
-            }
-        }
+        self.buffer.extend_from_slice(&temp_buf[..bytes_read]);
 
         if self.buffer.is_empty() {
             return Ok(None);
         }
 
-        for chunk in self.buffer.split(|b| *b == 0).rev().filter(|c| !c.is_empty()) {
+        // Parse from the stream, looking for complete plist records
+        // We split by null bytes and try to parse each chunk
+        for chunk in self
+            .buffer
+            .split(|b| *b == 0)
+            .rev()
+            .filter(|c| !c.is_empty())
+        {
             if let Ok(snapshot) = plist::from_reader::<_, RawSnapshot>(Cursor::new(chunk)) {
+                // Keep only the latest complete record in buffer
+                // Find the position of this chunk in the buffer
+                if let Some(pos) = self.buffer.windows(chunk.len()).position(|w| w == chunk) {
+                    self.buffer = self.buffer[pos..].to_vec();
+                }
                 return Ok(Some(convert_snapshot(snapshot)));
             }
         }


### PR DESCRIPTION
Implement PowermetricsReader::reader and PowermetricsReader::buffer to manage intermediate plist content, and implement PowermetricsReader::parse to read from buffer. 

As we're using pipe to store intermediate contents, there is no need to repeatedly restart the powermetrics process, so the related codes are removed (keeps cli arguments for compatibility)